### PR TITLE
feat: add ToastContainer component and useToast hook (#137)

### DIFF
--- a/components/atoms/toast/index.tsx
+++ b/components/atoms/toast/index.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useCallback } from 'react';
+import styles from './toast.module.css';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+}
+
+interface ToastItemProps {
+  toast: Toast;
+  onDismiss: (id: string) => void;
+}
+
+function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  const dismiss = useCallback(() => onDismiss(toast.id), [toast.id, onDismiss]);
+
+  useEffect(() => {
+    const timer = setTimeout(dismiss, toast.duration ?? 4000);
+    return () => clearTimeout(timer);
+  }, [dismiss, toast.duration]);
+
+  return (
+    <div className={`${styles.toast} ${styles[toast.type]}`} role="alert" aria-live="assertive">
+      <span className={styles.icon}>{ICONS[toast.type]}</span>
+      <p className={styles.message}>{toast.message}</p>
+      <button
+        className={styles.close}
+        onClick={dismiss}
+        aria-label="Dismiss notification"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+interface ToastContainerProps {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className={styles.container} aria-label="Notifications">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+const ICONS: Record<ToastType, string> = {
+  success: '✓',
+  error: '✕',
+  warning: '⚠',
+  info: 'ℹ',
+};

--- a/components/atoms/toast/toast.module.css
+++ b/components/atoms/toast/toast.module.css
@@ -1,0 +1,62 @@
+.container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 9999;
+  max-width: 360px;
+  width: 100%;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: slideIn 0.2s ease-out;
+  color: #fff;
+  font-size: 0.875rem;
+}
+
+.icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.message {
+  flex: 1;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.close:hover { opacity: 1; }
+
+.success { background-color: #16a34a; }
+.error   { background-color: #dc2626; }
+.warning { background-color: #d97706; }
+.info    { background-color: #2563eb; }
+
+@keyframes slideIn {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+@media (max-width: 480px) {
+  .container { left: 1rem; right: 1rem; bottom: 1rem; max-width: 100%; }
+}

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import type { Toast, ToastType } from '../components/atoms/toast';
+
+let counter = 0;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const show = useCallback(
+    (message: string, type: ToastType = 'info', duration?: number) => {
+      const id = `toast-${++counter}`;
+      setToasts((prev) => [...prev, { id, message, type, duration }]);
+    },
+    []
+  );
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const success = useCallback((msg: string) => show(msg, 'success'), [show]);
+  const error   = useCallback((msg: string) => show(msg, 'error'),   [show]);
+  const warning = useCallback((msg: string) => show(msg, 'warning'), [show]);
+  const info    = useCallback((msg: string) => show(msg, 'info'),    [show]);
+
+  return { toasts, show, dismiss, success, error, warning, info };
+}


### PR DESCRIPTION
Fixes #137\n\n## What changed\n- Added `components/atoms/toast/` with `ToastContainer` + `ToastItem` (success/error/warning/info variants, auto-dismiss, ARIA live region)\n- Added `hooks/useToast.ts` with `show()`, `dismiss()`, `success()`, `error()`, `warning()`, `info()` helpers\n- Slide-in animation and mobile-responsive layout