### PR TITLE
feat: add dark/light mode toggle with system preference detection (#134)

### DIFF
--- a/components/atoms/theme-toggle/index.tsx
+++ b/components/atoms/theme-toggle/index.tsx
@@ -1,0 +1,20 @@
+import { useTheme } from '../../../hooks/useTheme';
+import styles from './theme-toggle.module.css';
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      onClick={toggle}
+      className={styles.toggle}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Light mode' : 'Dark mode'}
+    >
+      <span className={styles.icon} aria-hidden="true">
+        {isDark ? '☀️' : '🌙'}
+      </span>
+    </button>
+  );
+}

--- a/components/atoms/theme-toggle/theme-toggle.module.css
+++ b/components/atoms/theme-toggle/theme-toggle.module.css
@@ -1,0 +1,41 @@
+.toggle {
+  background: none;
+  border: 1.5px solid var(--border-color, #ccc);
+  border-radius: 50%;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  font-size: 1rem;
+}
+
+.toggle:hover {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+  border-color: var(--border-hover, #999);
+}
+
+.icon { line-height: 1; }
+
+/* Dark theme CSS variables */
+:root[data-theme='dark'] {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --text: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --border-color: #334155;
+  --border-hover: #64748b;
+  --hover-bg: rgba(255, 255, 255, 0.08);
+}
+
+:root[data-theme='light'] {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --text-secondary: #64748b;
+  --border-color: #e2e8f0;
+  --border-hover: #cbd5e1;
+  --hover-bg: rgba(0, 0, 0, 0.04);
+}

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'trustflow-theme';
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const resolved = stored ?? getSystemTheme();
+    setTheme(resolved);
+    document.documentElement.setAttribute('data-theme', resolved);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setTheme((prev) => {
+      const next: Theme = prev === 'light' ? 'dark' : 'light';
+      localStorage.setItem(STORAGE_KEY, next);
+      document.documentElement.setAttribute('data-theme', next);
+      return next;
+    });
+  }, []);
+
+  return { theme, toggle };
+}


### PR DESCRIPTION
Fixes #134\n\n## What changed\n- Added `hooks/useTheme.ts` — reads system preference, persists to localStorage, applies `data-theme` to `<html>`\n- Added `ThemeToggle` button component with accessible aria-label\n- CSS custom properties for both themes (`--bg`, `--surface`, `--text`, `--border-color`)