### PR TITLE
feat: create responsive mobile navbar with hamburger menu (#139)

### DIFF
--- a/components/organisms/navbar/index.tsx
+++ b/components/organisms/navbar/index.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import styles from './navbar.module.css';
+
+const NAV_LINKS = [
+  { label: 'Home',      href: '/'          },
+  { label: 'Explore',   href: '/explore'   },
+  { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Escrow',    href: '/escrow'    },
+];
+
+export function Navbar() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const toggle = () => setOpen((v) => !v);
+  const close  = () => setOpen(false);
+
+  return (
+    <nav className={styles.nav} role="navigation" aria-label="Main navigation">
+      {/* Brand */}
+      <Link href="/" className={styles.brand} onClick={close}>
+        TrustFlow
+      </Link>
+
+      {/* Desktop links */}
+      <ul className={styles.links}>
+        {NAV_LINKS.map(({ label, href }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              className={`${styles.link} ${router.pathname === href ? styles.active : ''}`}
+            >
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {/* Hamburger (mobile) */}
+      <button
+        className={styles.hamburger}
+        onClick={toggle}
+        aria-expanded={open}
+        aria-label={open ? 'Close menu' : 'Open menu'}
+      >
+        <span /><span /><span />
+      </button>
+
+      {/* Mobile drawer */}
+      {open && (
+        <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Navigation menu">
+          <ul className={styles.drawerLinks}>
+            {NAV_LINKS.map(({ label, href }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`${styles.drawerLink} ${router.pathname === href ? styles.active : ''}`}
+                  onClick={close}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/components/organisms/navbar/navbar.module.css
+++ b/components/organisms/navbar/navbar.module.css
@@ -1,0 +1,107 @@
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  height: 4rem;
+  background: var(--surface, #fff);
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text, #0f172a);
+  text-decoration: none;
+}
+
+/* Desktop nav */
+.links {
+  display: flex;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.link {
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: var(--text-secondary, #64748b);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.link:hover { background: var(--hover-bg, #f1f5f9); color: var(--text, #0f172a); }
+.link.active { background: var(--hover-bg, #f1f5f9); color: var(--text, #0f172a); font-weight: 600; }
+
+/* Hamburger button */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.hamburger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--text, #0f172a);
+  border-radius: 2px;
+  transition: background 0.2s;
+}
+
+/* Mobile drawer */
+.drawer {
+  position: fixed;
+  top: 4rem;
+  left: 0;
+  right: 0;
+  background: var(--surface, #fff);
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  padding: 1rem 1.5rem;
+  animation: slideDown 0.18s ease-out;
+}
+
+.drawerLinks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.drawerLink {
+  display: block;
+  padding: 0.625rem 0.75rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  color: var(--text-secondary, #64748b);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.drawerLink:hover,
+.drawerLink.active { background: var(--hover-bg, #f1f5f9); color: var(--text, #0f172a); font-weight: 600; }
+
+@keyframes slideDown {
+  from { transform: translateY(-8px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+/* Show hamburger on mobile, hide desktop links */
+@media (max-width: 768px) {
+  .links     { display: none; }
+  .hamburger { display: flex; }
+}


### PR DESCRIPTION
Fixes #139\n\n## What changed\n- Added `components/organisms/navbar/` with sticky `Navbar` component\n- Desktop: horizontal link list with active route highlighting\n- Mobile (≤768px): hamburger button reveals slide-down drawer\n- Fully accessible: `aria-expanded`, `role=dialog` on mobile drawer