### PR TITLE
feat(gigs): add gig listing CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ TrustFlow Core is the backend API service that powers off-chain logic for the Tr
 
 - 🔐 **JWT Authentication with Wallet Signatures**: Secure wallet-based auth using Stellar signature verification. Users authenticate by signing a cryptographic challenge with their Freighter wallet, proving ownership without exposing private keys.
 - 💼 **Escrow Management**: Full CRUD API for escrow entities — creation, funding, milestone tracking.
+- **Gig Listings**: CRUD API for open client solicitations, including status and skill filters.
 - 🌐 **Stellar Integration**: Native Horizon and Soroban RPC helpers for on-chain reads and writes.
 - 🔔 **Webhook Engine**: Event-driven webhook dispatch with automatic retry logic.
 - 📊 **Monitoring & Metrics**: Built-in Prometheus metrics, health checks, and alerting helpers.
@@ -27,6 +28,7 @@ backend/
 │   │   ├── dto/            # Request/response DTOs for validation
 │   │   └── auth.module.ts # Auth module configuration
 │   ├── escrow/             # Escrow API — controller, service, DTOs, entity
+│   ├── gigs/               # Gig listing API — controller, service, DTOs, entity
 │   ├── stellar/            # Stellar helpers — Horizon, Soroban, config, service
 │   ├── webhook/            # Webhook dispatch — controller, service, retry helper
 │   ├── monitoring/         # Health checks, metrics, Prometheus helpers
@@ -133,6 +135,15 @@ curl http://localhost:3001/escrows \
 - **`GET /escrow/depositor/:address`** — Get all escrows by depositor
 - **`POST /escrow/:id/release`** — Approve a milestone tranche.
 - **`POST /escrow/:id/dispute`** — Raise a dispute (triggers Discord notification).
+
+### Gig Listings (`/gigs`)
+
+- **`POST /gigs`** - Create an open gig solicitation.
+- **`GET /gigs`** - List gig solicitations; supports `clientAddress`, `status`, `category`, and `skill` filters.
+- **`GET /gigs/:id`** - Fetch a single gig listing.
+- **`PATCH /gigs/:id`** - Update listing fields or status.
+- **`POST /gigs/:id/close`** - Close a listing without deleting its history.
+- **`DELETE /gigs/:id`** - Delete a listing.
 
 ### Webhooks (`/webhook`)
 

--- a/backend/API_DOCUMENTATION.md
+++ b/backend/API_DOCUMENTATION.md
@@ -31,6 +31,7 @@ The TrustFlow Backend API provides off-chain services for the TrustFlow gig econ
 
 - **Authentication**: Wallet-based JWT authentication using Stellar signatures
 - **Escrow Management**: Create, manage, and release escrow vaults
+- **Gig Listings**: Publish and manage open gig solicitations
 - **Dispute Resolution**: Raise disputes and trigger juror notifications
 - **Webhooks**: Register endpoints to receive event notifications
 - **Monitoring**: Health checks and Prometheus metrics
@@ -88,6 +89,17 @@ The TrustFlow Backend API provides off-chain services for the TrustFlow gig econ
 | GET    | `/escrows/depositor/:address` | Get escrows by depositor |
 | POST   | `/escrows/:id/release`        | Release escrow funds     |
 | POST   | `/escrows/:id/dispute`        | Raise a dispute          |
+
+### Gig Listings
+
+| Method | Endpoint          | Description                                  |
+| ------ | ----------------- | -------------------------------------------- |
+| POST   | `/gigs`           | Create an open gig solicitation              |
+| GET    | `/gigs`           | List gig solicitations with optional filters |
+| GET    | `/gigs/:id`       | Get a gig listing by ID                      |
+| PATCH  | `/gigs/:id`       | Update mutable listing fields or status      |
+| POST   | `/gigs/:id/close` | Close a gig listing                          |
+| DELETE | `/gigs/:id`       | Delete a gig listing                         |
 
 ### Webhooks
 
@@ -158,7 +170,26 @@ curl -X POST http://localhost:3001/escrows/esc-1234567890/dispute \
 - Webhook event (`dispute.raised`)
 - Discord notification (if configured)
 
-### 3. Register a Webhook
+### 3. Create a Gig Listing
+
+```bash
+curl -X POST http://localhost:3001/gigs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientAddress": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "title": "Build a Soroban escrow dashboard",
+    "description": "Create a dashboard for tracking escrow milestones and gig delivery state.",
+    "budgetXLM": "250.0000000",
+    "category": "development",
+    "skills": ["NestJS", "Soroban"]
+  }'
+```
+
+Use `GET /gigs?status=open&skill=Soroban` to discover matching open
+solicitations. Close completed or cancelled solicitations with
+`POST /gigs/:id/close`.
+
+### 4. Register a Webhook
 
 ```bash
 curl -X POST http://localhost:3001/webhooks \

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { SentryModule } from './sentry/sentry.module';
 import { RedisModule } from './common/redis/redis.module';
 import { RateLimitModule } from './common/rate-limit/rate-limit.module';
 import { UserProfileModule } from './user-profile/user-profile.module';
+import { GigModule } from './gigs/gig.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserProfileModule } from './user-profile/user-profile.module';
     RateLimitModule,
     AuthModule,
     UserProfileModule,
+    GigModule,
     EscrowModule,
     WebhookModule,
     MonitoringModule,

--- a/backend/src/gigs/gig.controller.spec.ts
+++ b/backend/src/gigs/gig.controller.spec.ts
@@ -1,0 +1,95 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { GigModule } from './gig.module';
+import { GigStatus } from './gig.entity';
+
+const clientAddress = `G${'A'.repeat(55)}`;
+
+describe('GigController', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [GigModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const validPayload = {
+    clientAddress,
+    title: 'Build a Soroban escrow dashboard',
+    description: 'Create a dashboard for tracking escrow milestones and gig delivery state.',
+    budgetXLM: '250.0000000',
+    category: 'development',
+    skills: ['NestJS', 'Soroban'],
+  };
+
+  it('creates, reads, updates, closes, and deletes a gig listing', async () => {
+    const createResponse = await request(app.getHttpServer())
+      .post('/gigs')
+      .send(validPayload)
+      .expect(201);
+
+    expect(createResponse.body).toMatchObject({
+      clientAddress,
+      title: validPayload.title,
+      status: GigStatus.OPEN,
+    });
+
+    const id = createResponse.body.id as string;
+
+    await request(app.getHttpServer())
+      .get('/gigs')
+      .query({ clientAddress, status: GigStatus.OPEN, skill: 'soroban' })
+      .expect(200)
+      .expect(response => {
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].id).toBe(id);
+      });
+
+    await request(app.getHttpServer())
+      .get(`/gigs/${id}`)
+      .expect(200)
+      .expect(response => {
+        expect(response.body.id).toBe(id);
+      });
+
+    await request(app.getHttpServer())
+      .patch(`/gigs/${id}`)
+      .send({ title: 'Build an escrow analytics dashboard' })
+      .expect(200)
+      .expect(response => {
+        expect(response.body.title).toBe('Build an escrow analytics dashboard');
+      });
+
+    await request(app.getHttpServer())
+      .post(`/gigs/${id}/close`)
+      .expect(201)
+      .expect(response => {
+        expect(response.body.status).toBe(GigStatus.CLOSED);
+        expect(response.body.closedAt).toBeDefined();
+      });
+
+    await request(app.getHttpServer()).delete(`/gigs/${id}`).expect(204);
+    await request(app.getHttpServer()).get(`/gigs/${id}`).expect(404);
+  });
+
+  it('returns 400 for invalid create payloads and query filters', async () => {
+    await request(app.getHttpServer())
+      .post('/gigs')
+      .send({ ...validPayload, clientAddress: 'bad-address' })
+      .expect(400)
+      .expect(response => {
+        expect(response.body.message).toBe('Invalid gig listing payload');
+      });
+
+    await request(app.getHttpServer()).get('/gigs').query({ status: 'archived' }).expect(400);
+  });
+});

--- a/backend/src/gigs/gig.controller.ts
+++ b/backend/src/gigs/gig.controller.ts
@@ -1,0 +1,140 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import {
+  CreateGigDto,
+  CreateGigSchema,
+  GigFiltersSchema,
+  UpdateGigDto,
+  UpdateGigSchema,
+} from './gig.dto';
+import { GigStatus } from './gig.entity';
+import { GigService } from './gig.service';
+
+@ApiTags('Gig Listings')
+@Controller('gigs')
+export class GigController {
+  constructor(private readonly gigService: GigService) {}
+
+  private parseOrThrow<T>(schema: z.ZodSchema<T>, value: unknown): T {
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException({
+        message: 'Invalid gig listing payload',
+        errors: result.error.issues.map(issue => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
+    }
+    return result.data;
+  }
+
+  @Post()
+  @ApiOperation({
+    summary: 'Create a gig listing',
+    description: 'Creates an open gig solicitation for clients seeking freelancers.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['clientAddress', 'title', 'description', 'budgetXLM'],
+      properties: {
+        clientAddress: {
+          type: 'string',
+          example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        },
+        title: { type: 'string', example: 'Build a Soroban escrow dashboard' },
+        description: {
+          type: 'string',
+          example: 'Create a dashboard for tracking escrow milestones.',
+        },
+        budgetXLM: { type: 'string', example: '250.0000000' },
+        category: { type: 'string', example: 'development' },
+        skills: { type: 'array', items: { type: 'string' }, example: ['NestJS', 'Soroban'] },
+        deadline: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Gig listing created' })
+  @ApiResponse({ status: 400, description: 'Invalid gig listing payload' })
+  async create(@Body() dto: CreateGigDto) {
+    const validated = this.parseOrThrow(CreateGigSchema, dto);
+    return this.gigService.create({ ...validated, skills: validated.skills ?? [] });
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'List gig listings',
+    description:
+      'Lists open gig solicitations with optional client, status, category, and skill filters.',
+  })
+  @ApiQuery({ name: 'clientAddress', required: false, type: String })
+  @ApiQuery({ name: 'status', required: false, enum: GigStatus })
+  @ApiQuery({ name: 'category', required: false, type: String })
+  @ApiQuery({ name: 'skill', required: false, type: String })
+  @ApiResponse({ status: 200, description: 'Gig listing collection' })
+  async findAll(
+    @Query('clientAddress') clientAddress?: string,
+    @Query('status') status?: GigStatus,
+    @Query('category') category?: string,
+    @Query('skill') skill?: string,
+  ) {
+    const filters = this.parseOrThrow(GigFiltersSchema, { clientAddress, status, category, skill });
+    return this.gigService.findAll(filters);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a gig listing by ID' })
+  @ApiParam({ name: 'id', description: 'Gig listing ID' })
+  @ApiResponse({ status: 200, description: 'Gig listing details' })
+  @ApiResponse({ status: 404, description: 'Gig listing not found' })
+  async findById(@Param('id') id: string) {
+    return this.gigService.findById(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: 'Update a gig listing',
+    description: 'Updates mutable gig listing fields or transitions listing status.',
+  })
+  @ApiParam({ name: 'id', description: 'Gig listing ID' })
+  @ApiResponse({ status: 200, description: 'Gig listing updated' })
+  @ApiResponse({ status: 400, description: 'Invalid transition or payload' })
+  @ApiResponse({ status: 404, description: 'Gig listing not found' })
+  async update(@Param('id') id: string, @Body() dto: UpdateGigDto) {
+    const validated = this.parseOrThrow(UpdateGigSchema, dto);
+    return this.gigService.update(id, validated);
+  }
+
+  @Post(':id/close')
+  @ApiOperation({ summary: 'Close a gig listing' })
+  @ApiParam({ name: 'id', description: 'Gig listing ID' })
+  @ApiResponse({ status: 200, description: 'Gig listing closed' })
+  @ApiResponse({ status: 404, description: 'Gig listing not found' })
+  async close(@Param('id') id: string) {
+    return this.gigService.close(id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a gig listing' })
+  @ApiParam({ name: 'id', description: 'Gig listing ID' })
+  @ApiResponse({ status: 204, description: 'Gig listing deleted' })
+  @ApiResponse({ status: 404, description: 'Gig listing not found' })
+  async delete(@Param('id') id: string) {
+    await this.gigService.delete(id);
+  }
+}

--- a/backend/src/gigs/gig.dto.ts
+++ b/backend/src/gigs/gig.dto.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { GigStatus } from './gig.entity';
+
+const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
+const XLM_AMOUNT_REGEX = /^(?:0|[1-9]\d*)(?:\.\d{1,7})?$/;
+
+const SkillsSchema = z
+  .array(z.string().trim().min(1, 'Skill cannot be empty').max(50, 'Skill is too long'))
+  .max(20, 'Maximum 20 skills allowed')
+  .default([]);
+
+export const CreateGigSchema = z.object({
+  clientAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'Invalid Stellar wallet address'),
+  title: z.string().trim().min(5, 'Title must be at least 5 characters').max(120),
+  description: z.string().trim().min(20, 'Description must be at least 20 characters').max(5000),
+  budgetXLM: z.string().regex(XLM_AMOUNT_REGEX, 'Invalid XLM amount'),
+  category: z.string().trim().min(2).max(80).optional(),
+  skills: SkillsSchema,
+  deadline: z.string().datetime({ offset: true }).optional(),
+});
+
+export type CreateGigDto = z.infer<typeof CreateGigSchema>;
+
+export const UpdateGigSchema = z.object({
+  title: z.string().trim().min(5).max(120).optional(),
+  description: z.string().trim().min(20).max(5000).optional(),
+  budgetXLM: z.string().regex(XLM_AMOUNT_REGEX, 'Invalid XLM amount').optional(),
+  category: z.string().trim().min(2).max(80).optional(),
+  skills: SkillsSchema.optional(),
+  status: z.nativeEnum(GigStatus).optional(),
+  deadline: z.string().datetime({ offset: true }).optional(),
+});
+
+export type UpdateGigDto = z.infer<typeof UpdateGigSchema>;
+
+export interface GigFilters {
+  clientAddress?: string;
+  status?: GigStatus;
+  category?: string;
+  skill?: string;
+}
+
+export const GigFiltersSchema = z.object({
+  clientAddress: z
+    .string()
+    .regex(STELLAR_ADDRESS_REGEX, 'Invalid Stellar wallet address')
+    .optional(),
+  status: z.nativeEnum(GigStatus).optional(),
+  category: z.string().trim().min(2).max(80).optional(),
+  skill: z.string().trim().min(1).max(50).optional(),
+});

--- a/backend/src/gigs/gig.entity.ts
+++ b/backend/src/gigs/gig.entity.ts
@@ -1,0 +1,21 @@
+export enum GigStatus {
+  OPEN = 'open',
+  PAUSED = 'paused',
+  FILLED = 'filled',
+  CLOSED = 'closed',
+}
+
+export interface GigListing {
+  id: string;
+  clientAddress: string;
+  title: string;
+  description: string;
+  budgetXLM: string;
+  category?: string;
+  skills: string[];
+  status: GigStatus;
+  deadline?: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt?: string;
+}

--- a/backend/src/gigs/gig.module.ts
+++ b/backend/src/gigs/gig.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GigController } from './gig.controller';
+import { GigService } from './gig.service';
+
+@Module({
+  controllers: [GigController],
+  providers: [GigService],
+  exports: [GigService],
+})
+export class GigModule {}

--- a/backend/src/gigs/gig.service.spec.ts
+++ b/backend/src/gigs/gig.service.spec.ts
@@ -1,0 +1,86 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { GigStatus } from './gig.entity';
+import { GigService } from './gig.service';
+
+const clientAddress = `G${'A'.repeat(55)}`;
+
+describe('GigService', () => {
+  let service: GigService;
+
+  beforeEach(() => {
+    service = new GigService();
+  });
+
+  const createGig = () =>
+    service.create({
+      clientAddress,
+      title: 'Build a Soroban escrow dashboard',
+      description: 'Create a dashboard for tracking escrow milestones and gig delivery state.',
+      budgetXLM: '250.0000000',
+      category: 'development',
+      skills: ['NestJS', 'Soroban'],
+    });
+
+  it('creates an open gig listing', async () => {
+    const gig = await createGig();
+
+    expect(gig.id).toBeDefined();
+    expect(gig.clientAddress).toBe(clientAddress);
+    expect(gig.status).toBe(GigStatus.OPEN);
+    expect(gig.createdAt).toBeDefined();
+    expect(gig.updatedAt).toBeDefined();
+  });
+
+  it('lists and filters gig listings', async () => {
+    const first = await createGig();
+    await service.create({
+      clientAddress: `G${'B'.repeat(55)}`,
+      title: 'Design milestone review flow',
+      description: 'Design and document a milestone approval flow for client reviews.',
+      budgetXLM: '125',
+      category: 'design',
+      skills: ['Figma'],
+    });
+
+    await service.close(first.id);
+
+    await expect(service.findAll()).resolves.toHaveLength(2);
+    await expect(service.findAll({ clientAddress })).resolves.toHaveLength(1);
+    await expect(service.findAll({ status: GigStatus.CLOSED })).resolves.toHaveLength(1);
+    await expect(service.findAll({ category: 'DEVELOPMENT' })).resolves.toHaveLength(1);
+    await expect(service.findAll({ skill: 'soroban' })).resolves.toHaveLength(1);
+  });
+
+  it('updates mutable fields and closes listings', async () => {
+    const gig = await createGig();
+
+    const updated = await service.update(gig.id, {
+      title: 'Build an escrow analytics dashboard',
+      skills: ['NestJS', 'Analytics'],
+    });
+
+    expect(updated.title).toBe('Build an escrow analytics dashboard');
+    expect(updated.skills).toEqual(['NestJS', 'Analytics']);
+
+    const closed = await service.close(gig.id);
+    expect(closed.status).toBe(GigStatus.CLOSED);
+    expect(closed.closedAt).toBeDefined();
+  });
+
+  it('does not reopen closed listings', async () => {
+    const gig = await createGig();
+    await service.close(gig.id);
+
+    await expect(service.update(gig.id, { status: GigStatus.OPEN })).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('deletes listings and reports missing records', async () => {
+    const gig = await createGig();
+    await service.delete(gig.id);
+
+    await expect(service.findById(gig.id)).rejects.toThrow(NotFoundException);
+    await expect(service.delete('missing-id')).rejects.toThrow(NotFoundException);
+  });
+});

--- a/backend/src/gigs/gig.service.ts
+++ b/backend/src/gigs/gig.service.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { GigListing, GigStatus } from './gig.entity';
+import { CreateGigDto, GigFilters, UpdateGigDto } from './gig.dto';
+
+@Injectable()
+export class GigService {
+  private readonly gigs: Map<string, GigListing> = new Map();
+
+  async create(dto: CreateGigDto): Promise<GigListing> {
+    const now = new Date().toISOString();
+    const gig: GigListing = {
+      id: randomUUID(),
+      clientAddress: dto.clientAddress,
+      title: dto.title,
+      description: dto.description,
+      budgetXLM: dto.budgetXLM,
+      category: dto.category,
+      skills: dto.skills ?? [],
+      status: GigStatus.OPEN,
+      deadline: dto.deadline,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.gigs.set(gig.id, gig);
+    return gig;
+  }
+
+  async findAll(filters: GigFilters = {}): Promise<GigListing[]> {
+    return Array.from(this.gigs.values()).filter(gig => {
+      if (filters.clientAddress && gig.clientAddress !== filters.clientAddress) return false;
+      if (filters.status && gig.status !== filters.status) return false;
+      if (filters.category && gig.category?.toLowerCase() !== filters.category.toLowerCase()) {
+        return false;
+      }
+      if (
+        filters.skill &&
+        !gig.skills.some(skill => skill.toLowerCase() === filters.skill?.toLowerCase())
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  async findById(id: string): Promise<GigListing> {
+    const gig = this.gigs.get(id);
+    if (!gig) {
+      throw new NotFoundException('Gig listing not found');
+    }
+    return gig;
+  }
+
+  async update(id: string, dto: UpdateGigDto): Promise<GigListing> {
+    const gig = await this.findById(id);
+
+    if (
+      gig.status === GigStatus.CLOSED &&
+      dto.status !== undefined &&
+      dto.status !== GigStatus.CLOSED
+    ) {
+      throw new BadRequestException('Closed gig listings cannot be reopened');
+    }
+
+    const nextStatus = dto.status ?? gig.status;
+    const now = new Date().toISOString();
+    const updated: GigListing = {
+      ...gig,
+      ...dto,
+      skills: dto.skills ?? gig.skills,
+      status: nextStatus,
+      updatedAt: now,
+      closedAt: nextStatus === GigStatus.CLOSED ? (gig.closedAt ?? now) : gig.closedAt,
+    };
+
+    this.gigs.set(id, updated);
+    return updated;
+  }
+
+  async close(id: string): Promise<GigListing> {
+    return this.update(id, { status: GigStatus.CLOSED });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findById(id);
+    this.gigs.delete(id);
+  }
+
+  clear(): void {
+    this.gigs.clear();
+  }
+}

--- a/backend/src/gigs/index.ts
+++ b/backend/src/gigs/index.ts
@@ -1,0 +1,5 @@
+export * from './gig.controller';
+export * from './gig.dto';
+export * from './gig.entity';
+export * from './gig.module';
+export * from './gig.service';


### PR DESCRIPTION
## Summary

- adds a new NestJS `GigModule` mounted at `/gigs`
- supports create, list with filters, read by id, update, close, and delete flows for open gig solicitations
- adds Zod validation with standard `400` responses for invalid create/update/query payloads
- adds Swagger decorators and documentation for the new gig listing resource
- covers service behavior and HTTP behavior with unit/Supertest specs

Closes #30

## Validation

- `pnpm exec jest src/gigs/gig.service.spec.ts src/gigs/gig.controller.spec.ts --runInBand`
- `pnpm run build`
- `pnpm exec eslint src/app.module.ts src/gigs/*.ts --max-warnings 0`
- `pnpm exec jest --runInBand`
- `git diff --check`

Note: the repository currently has many existing CRLF/Prettier findings when running the full `lint:check` command in this Windows checkout. The touched TypeScript files pass targeted ESLint/Prettier checks, and the full Jest suite plus TypeScript build pass.
